### PR TITLE
ci: Replace jekyll-actions with setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,14 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
+      # Converts the markdown into HTML files so htmlproofer can work
       - name: Build the Jekyll site
-        uses: helaili/jekyll-action@v2
+        uses: ruby/setup-ruby@v1
         with:
-          # Only build, don't publish
-          build_only: true
-          # Set _site as the destination directory
-          jekyll_build_options: -d _site
-        env:
-          # Fix GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
-          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fix jekyll-github-metadata/repository_finder.rb:29:in `block in nwo': No repo name found.
-          PAGES_REPO_NWO: ${{ github.repository }}
+          # https://pages.github.com/versions/
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec jekyll build
 
       - name: Check internal links using htmlproofer
         uses: anishathalye/proof-html@v1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Ruby and dependencies
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,19 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
-      # Converts the markdown into HTML files so htmlproofer can work
-      - name: Build the Jekyll site
+      - name: Install Ruby and dependencies
         uses: ruby/setup-ruby@v1
         with:
           # https://pages.github.com/versions/
           ruby-version: '2.7'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec jekyll build
+
+      # Converts the markdown into HTML files so htmlproofer can work
+      - name: Build the Jekyll site
+        run: bundle exec jekyll build
+        env:
+          # Fix GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check internal links using htmlproofer
         uses: anishathalye/proof-html@v1.4.0


### PR DESCRIPTION
jekyll-actions is deprecated and is throwing an error:

'ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is incompatible with the current version, 3.1.6'